### PR TITLE
Updating the version element to use properties 

### DIFF
--- a/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.nuspec
+++ b/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.nuspec
@@ -2,7 +2,7 @@
   <metadata>
     <id>Infragistics.DataPresenter.DataSources.OData</id>
     <title>OData DataSource Reference Implementation for Infragistics XamDataPresenter</title>
-    <version>1.0.0-beta</version>
+    <version>$naVersionMajor$.$naVersionMinor$.$naVersionRevision$</version>
     <authors>Infragistics, Inc.</authors>
     <owners>Infragistics, Inc</owners>
     <description>Installs the DataPresenter.DataSources.OData.dll assembly which contains a reference implementation for an OData data source based on the AsyncPagingDataSourceBase class delivered in InfragisticsWPF4.DataPresenter.DataSources.Async.v16.1</description>

--- a/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.nuspec
+++ b/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.nuspec
@@ -5,7 +5,7 @@
     <version>$naVersionMajor$.$naVersionMinor$.$naVersionRevision$</version>
     <authors>Infragistics, Inc.</authors>
     <owners>Infragistics, Inc</owners>
-    <description>Installs the DataPresenter.DataSources.OData.dll assembly which contains a reference implementation for an OData data source based on the AsyncPagingDataSourceBase class delivered in InfragisticsWPF4.DataPresenter.DataSources.Async.v16.1</description>
+    <description>Installs the DataPresenter.DataSources.OData.dll assembly which contains a reference implementation for an OData data source based on the AsyncPagingDataSourceBase class delivered in InfragisticsWPF4.DataPresenter.DataSources.Async.v$naVersionMajor$.$naVersionMinor$</description>
     <projectUrl>https://github.com/Infragistics/DataSource-Reference-Implementations/tree/master/DataPresenter.DataSources.OData</projectUrl>
     <licenseUrl>https://github.com/Infragistics/DataSource-Reference-Implementations/blob/master/LICENSE</licenseUrl>
     <iconUrl>http://www.infragistics.com/tempicon.png</iconUrl>


### PR DESCRIPTION
Updating the version element to use properties so we can automatically have it match the Major, Minor, and Revision number of the Infragistics WPF dependencies it's expecting.
