### PR TITLE
adding missing hint paths

### DIFF
--- a/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.SampleApp/DataPresenter.DataSources.OData.SampleApp.csproj
+++ b/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.SampleApp/DataPresenter.DataSources.OData.SampleApp.csproj
@@ -39,11 +39,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="InfragisticsWPF4.Controls.Editors.XamColorPicker.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.DataPresenter.DataSources.Async.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.DataPresenter.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.Editors.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
+    <Reference Include="InfragisticsWPF4.Controls.Editors.XamColorPicker.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.Controls.Editors.XamColorPicker.v19.2.dll</HintPath>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.DataPresenter.DataSources.Async.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.DataPresenter.DataSources.Async.v19.2.dll</HintPath>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.DataPresenter.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.DataPresenter.v19.2.dll</HintPath>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.Editors.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.Editors.v19.2.dll</HintPath>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.v19.2.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.csproj
+++ b/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData/DataPresenter.DataSources.OData.csproj
@@ -32,9 +32,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="InfragisticsWPF4.DataPresenter.DataSources.Async.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
+    <Reference Include="InfragisticsWPF4.DataPresenter.DataSources.Async.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.DataPresenter.DataSources.Async.v19.2.dll</HintPath>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.DataVisualization.v19.2.dll</HintPath>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.v19.2.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.8.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>

--- a/DataSource.DataProviders.OData/DataSource.DataProviders.OData.Core/DataSource.DataProviders.OData.Core.csproj
+++ b/DataSource.DataProviders.OData/DataSource.DataProviders.OData.Core/DataSource.DataProviders.OData.Core.csproj
@@ -14,13 +14,16 @@
 
   <ItemGroup>
     <Reference Include="Infragistics.Core">
-      <HintPath>..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include="Infragistics.Core.DataVisualization">
-      <HintPath>..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.DataVisualization.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.DataVisualization.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include="Infragistics.Core.Platform">
-      <HintPath>..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.Platform.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.Platform.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
   </ItemGroup>
 

--- a/DataSource.DataProviders.OData/DataSource.DataProviders.OData/DataSource.DataProviders.OData.csproj
+++ b/DataSource.DataProviders.OData/DataSource.DataProviders.OData/DataSource.DataProviders.OData.csproj
@@ -32,8 +32,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
+    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.DataVisualization.v19.2.dll</HintPath>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.v19.2.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.8.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>

--- a/DataSource.DataProviders.OData/ODataSampleApp/ODataSampleApp.csproj
+++ b/DataSource.DataProviders.OData/ODataSampleApp/ODataSampleApp.csproj
@@ -37,9 +37,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="InfragisticsWPF4.Controls.Grids.XGrid.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
+    <Reference Include="InfragisticsWPF4.Controls.Grids.XGrid.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.Controls.Grids.XGrid.v19.2.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.DataVisualization.v19.2.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.v19.2.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.8.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Data.Edm.5.8.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>

--- a/DataSource.DataProviders.SQLite/DataSource.DataProviders.SQLite.Core/DataSource.DataProviders.SQLite.Core.csproj
+++ b/DataSource.DataProviders.SQLite/DataSource.DataProviders.SQLite.Core/DataSource.DataProviders.SQLite.Core.csproj
@@ -16,13 +16,16 @@
 
   <ItemGroup>
     <Reference Include="Infragistics.Core">
-      <HintPath>..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include="Infragistics.Core.DataVisualization">
-      <HintPath>..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.DataVisualization.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.DataVisualization.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include="Infragistics.Core.Platform">
-      <HintPath>..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.Platform.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\Xamarin\2019.2\Source\Build\netstandard2.0\Infragistics.Core.Platform.dll</HintPath>
+      <SpecificVersion>false</SpecificVersion>
     </Reference>
   </ItemGroup>
 

--- a/DataSource.DataProviders.SQLite/DataSource.DataProviders.SQLite/DataSource.DataProviders.SQLite.csproj
+++ b/DataSource.DataProviders.SQLite/DataSource.DataProviders.SQLite/DataSource.DataProviders.SQLite.csproj
@@ -32,8 +32,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL" />
-    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL" />
+    <Reference Include="InfragisticsWPF4.DataVisualization.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=1102135f7483647e, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.DataVisualization.v19.2.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="InfragisticsWPF4.v19.2, Version=19.2.0.9000, Culture=neutral, PublicKeyToken=7dd5c3163f2cd0cb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\..\work\NetAdvantage\DEV\XAML\2019.2\Source\Build\InfragisticsWPF4.v19.2.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="SQLite-net, Version=1.6.292.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
When I updated the assembly references in the projects I did not update them properly so they were looking for specific versions which may not necessarily be on the build machine.  As such I put back the specific version setting so it doesn't require the 9000 version assemblies.  I also added back the hint paths so our build machine can find the assemblies.